### PR TITLE
Sean

### DIFF
--- a/GuardiansoftheSpectrum/app/src/main/java/edu/colorado/gots/guardiansofthespectrum/JSONBuilder.java
+++ b/GuardiansoftheSpectrum/app/src/main/java/edu/colorado/gots/guardiansofthespectrum/JSONBuilder.java
@@ -4,6 +4,7 @@ package edu.colorado.gots.guardiansofthespectrum;
 import android.location.Location;
 import android.net.wifi.ScanResult;
 import android.os.Build;
+import android.telephony.CellInfoLte;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -121,13 +122,16 @@ public class JSONBuilder {
         JSONObject ret = new JSONObject();
        try {
            System.out.println("building lte JSON\n");
-           ret.put("Dbm", lte.getLTEinfo().getCellSignalStrength().getDbm());
-           ret.put("CellID", lte.getLTEinfo().getCellIdentity().getCi());
-           ret.put("MCC", lte.getLTEinfo().getCellIdentity().getMcc());
-           ret.put("MNC", lte.getLTEinfo().getCellIdentity().getMnc());
-           ret.put("PCI", lte.getLTEinfo().getCellIdentity().getPci());
-           ret.put("TAC", lte.getLTEinfo().getCellIdentity().getTac());
-           ret.put("TimingAdvance", lte.getLTEinfo().getCellSignalStrength().getTimingAdvance());
+           CellInfoLte cellInfo = lte.getLTEinfo();
+           if (cellInfo != null) {
+               ret.put("Dbm", cellInfo.getCellSignalStrength().getDbm());
+               ret.put("CellID", cellInfo.getCellIdentity().getCi());
+               ret.put("MCC", cellInfo.getCellIdentity().getMcc());
+               ret.put("MNC", cellInfo.getCellIdentity().getMnc());
+               ret.put("PCI", cellInfo.getCellIdentity().getPci());
+               ret.put("TAC", cellInfo.getCellIdentity().getTac());
+               ret.put("TimingAdvance", cellInfo.getCellSignalStrength().getTimingAdvance());
+           }
            ret.put("RSSNR", lte.getRssnr());
            ret.put("CQI", lte.getCqi());
            //ret.put("RSRP", lte.getRsrp());
@@ -157,7 +161,6 @@ public class JSONBuilder {
             ret.put("Manufacturer", Build.MANUFACTURER);
             ret.put("Model", Build.MODEL);
             ret.put("Product", Build.PRODUCT);
-            ret.put("Serial", Build.SERIAL);
             ret.put("Tags", Build.TAGS);
             ret.put("Time", Build.TIME);
             ret.put("Type", Build.TYPE);

--- a/GuardiansoftheSpectrum/app/src/main/java/edu/colorado/gots/guardiansofthespectrum/ScanActivity.java
+++ b/GuardiansoftheSpectrum/app/src/main/java/edu/colorado/gots/guardiansofthespectrum/ScanActivity.java
@@ -144,16 +144,16 @@ public class ScanActivity extends LocationActivity {
      * Parses data received from scan data receiver.
      * If the data received is valid i.e. not NULL and Dbm and rssi are not max int,
      * will pass data to be added to corresponding datasets.
-     * @param data String of the JSON object of all collect info from ScanDataReceiver
+     * @param dbm Int Dbm of the current LTE signal strength
      * @param wifi_ssid String name of the currently connected wifi ap
-     * @param wifi_rssi Int singal strength of currently connected wifi ap
+     * @param wifi_rssi Int signal strength of currently connected wifi ap
      */
-    protected void ParseData(String data, String wifi_ssid, int wifi_rssi){
+    protected void ParseData(int dbm, String wifi_ssid, int wifi_rssi){
         //String[] objects = data.split(Pattern.quote("{"));
-        Log.d("ParseData", data);
+        Log.d("ParseData", Integer.toString(dbm));
         Log.d("ParseData", wifi_ssid);
         Log.d("ParseData", Integer.toString(wifi_rssi));
-        int pos = data.indexOf("Dbm");
+        /*int pos = data.indexOf("Dbm");
         int endPos = data.indexOf("CellID");
 
         // check to ensure the LTE object was not null
@@ -166,6 +166,10 @@ public class ScanActivity extends LocationActivity {
                 addEntry(dbm, wifi_ssid, wifi_rssi);
                 count++;
             }
+        }*/
+        if (dbm < 0 && wifi_rssi < 0) {
+            addEntry(dbm, wifi_ssid, wifi_rssi);
+            count++;
         }
     }
 
@@ -267,7 +271,9 @@ public class ScanActivity extends LocationActivity {
             WIFItext.setVisibility(VISIBLE);
             moreInfoLTE.setVisibility(VISIBLE);
             moreInfoWIFI.setVisibility(VISIBLE);
-            ParseData(i.getStringExtra(ScanService.GOTS_SCAN_SERVICE_RESULTS_EXTRA), i.getStringExtra(ScanService.GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_SSID), i.getIntExtra(ScanService.GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_RSSI, Integer.MAX_VALUE));
+            ParseData(i.getIntExtra(ScanService.GOTS_SCAN_SERVICE_RESULTS_LTE_DBM, Integer.MAX_VALUE),
+                    i.getStringExtra(ScanService.GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_SSID),
+                    i.getIntExtra(ScanService.GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_RSSI, Integer.MAX_VALUE));
         }
     }
 

--- a/GuardiansoftheSpectrum/app/src/main/java/edu/colorado/gots/guardiansofthespectrum/ScanService.java
+++ b/GuardiansoftheSpectrum/app/src/main/java/edu/colorado/gots/guardiansofthespectrum/ScanService.java
@@ -6,6 +6,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.location.Location;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiInfo;
@@ -17,6 +18,7 @@ import android.os.IBinder;
 import android.os.Looper;
 import android.os.Message;
 import android.os.Process;
+import android.preference.PreferenceManager;
 import android.support.v4.content.LocalBroadcastManager;
 import android.telephony.CellInfo;
 import android.telephony.CellInfoLte;
@@ -174,7 +176,7 @@ public class ScanService extends Service {
     /**
      * An Intent action indicating that the intent contains the results of our background scanning.
      * These results can be accessed by using various keys for the Extras.
-     * @see #GOTS_SCAN_SERVICE_RESULTS_EXTRA
+     * @see #GOTS_SCAN_SERVICE_RESULTS_LTE_DBM
      * @see #GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_SSID
      * @see #GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_RSSI
      */
@@ -184,7 +186,7 @@ public class ScanService extends Service {
      * scan.
      * @see #GOTS_SCAN_SERVICE_RESULTS
      */
-    public static final String GOTS_SCAN_SERVICE_RESULTS_EXTRA = "edu.colorado.gots.guardiansofthespectrum.scan.service.results.extra";
+    public static final String GOTS_SCAN_SERVICE_RESULTS_LTE_DBM = "edu.colorado.gots.guardiansofthespectrum.scan.service.results.lte.dbm";
     public static final String GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_SSID = "edu.colorado.gots.guardiansofthespectrum.scan.service.results.current.wifi.ssid";
     public static final String GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_RSSI = "edu.colorado.gots.guardiansofthespectrum.scan.service.results.current.wifi.rssi";
 
@@ -201,7 +203,7 @@ public class ScanService extends Service {
         dataFileManager = new DataFileManager(getApplicationContext());
         csvFileManager = new CSVFileManager(getApplicationContext());
         //grab the wifi manager instance
-        wifiManager = (WifiManager) getSystemService(Context.WIFI_SERVICE);
+        wifiManager = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         //instantiate a receiver class. defined below
         scanReceiver = new WifiScanReceiver();
         //ask for scan to start
@@ -333,6 +335,21 @@ public class ScanService extends Service {
         }
 
         /**
+         * Extract the current Dbm value of the CellInfoLte object returned by the phone state
+         * listeners. This object may be null if the phone is not currently connected to an LTE
+         * network. In this case, we return Integer.MAX_VALUE
+         * @param lte the CellInfoLTE object returned by the telephony listeners
+         * @return the Dbm of the current LTE signal strength, or Integer.MAX_VALUE if invalid
+         */
+        private int getLTEDbmOrMaxInt(CellInfoLte lte) {
+            if (lteNetwork && lte != null) {
+                return lte.getCellSignalStrength().getDbm();
+            } else {
+                return Integer.MAX_VALUE;
+            }
+        }
+
+        /**
          * Handle incoming messages to the scanning thread. This is where the main work occurs.
          * We sleep until all results come back from the listeners, then write the results to
          * persistent storage to be used later.
@@ -359,13 +376,22 @@ public class ScanService extends Service {
                 }
                 String jsonText = JSONBuilder.scanToJSON(LTE_Info, wifiInfo, currentLocation);
                 dataFileManager.writeToFile(jsonText);
+                //check if we need to send
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+                System.out.println("storage cap: " + prefs.getString("storageCap", "0"));
+                if (Integer.parseInt(prefs.getString("storageCap", "0")) < dataFileManager.getUsedStorageSize()) {
+                    //this will be replaced with new SendTask().execute(...data...)
+                    startActivity(new Intent(getApplicationContext(), SendActivity.class));
+                }
                 Intent resultsIntent = new Intent(GOTS_SCAN_SERVICE_RESULTS);
-                resultsIntent.putExtra(GOTS_SCAN_SERVICE_RESULTS_EXTRA, jsonText);
+                if (lteNetwork) {
+                    resultsIntent.putExtra(GOTS_SCAN_SERVICE_RESULTS_LTE_DBM, getLTEDbmOrMaxInt(LTEInfo));
+                }
                 WifiInfo currentWifi = wifiManager.getConnectionInfo();
                 resultsIntent.putExtra(GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_SSID, currentWifi.getSSID());
                 resultsIntent.putExtra(GOTS_SCAN_SERVICE_RESULTS_CURRENT_WIFI_RSSI, currentWifi.getRssi());
                 LocalBroadcastManager.getInstance(ScanService.this).sendBroadcast(resultsIntent);
-                csvFileManager.writeData(new Date().getTime(), LTEInfo.getCellSignalStrength().getDbm(),
+                csvFileManager.writeData(new Date().getTime(), getLTEDbmOrMaxInt(LTEInfo),
                         currentWifi.getSSID(), currentWifi.getRssi());
                 LTEInfo = null;
                 wifiInfo = null;

--- a/GuardiansoftheSpectrum/app/src/main/java/edu/colorado/gots/guardiansofthespectrum/ScanService.java
+++ b/GuardiansoftheSpectrum/app/src/main/java/edu/colorado/gots/guardiansofthespectrum/ScanService.java
@@ -381,8 +381,7 @@ public class ScanService extends Service {
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
                 System.out.println("storage cap: " + prefs.getString("storageCap", "0"));
                 if (Integer.parseInt(prefs.getString("storageCap", "0")) < dataFileManager.getUsedStorageSize()) {
-                    //this will be replaced with new SendTask().execute(...data...)
-                    startActivity(new Intent(getApplicationContext(), SendActivity.class));
+                    //this will be new SendTask().execute(...data...)
                 }
                 Intent resultsIntent = new Intent(GOTS_SCAN_SERVICE_RESULTS);
                 if (lteNetwork) {


### PR DESCRIPTION
- filesystem lock for eventual automatic sending/deletion of data
- send LTE DBm directly to listeners instead of having to parse full JSON string
- removed serial number from metadata information
- fix possible LTE null object reference in the JSONBuilder
- extra debug information in SendActivity and commented out version of plain HTTP send code just in case more issues crop up